### PR TITLE
Synchronize repository data with file changes

### DIFF
--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -9,7 +9,6 @@ require 'holidays/parser'
 require 'holidays/repository'
 require 'holidays/cache_repository'
 require 'holidays/date_calculator'
-require 'holidays/global_configuration'
 
 module Holidays
   WEEKS = {:first => 1, :second => 2, :third => 3, :fourth => 4, :fifth => 5, :last => -1, :second_last => -2, :third_last => -3}

--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -28,16 +28,9 @@ module Holidays
     end
 
     def load_new_definition(definition)
-      if definition.is_a? String
-        # If it's a string, expect it be be a file path to a parseable region definition
-        region_definition = Parser.parse_definition_file(definition)
-        repository.add_region_definition(region_definition)
-      elsif definition.is_a? Holidays::RegionDefinition
-        # If the user passes in their own RegionDefinition, then just add it directly
-        repository.add_region_definition definition
-      else
-        raise ArgumentError, "load_new_definition expects a file path or a pre-loaded RegionDefinition"
-      end
+      raise ArgumentError, "load_new_definition expects a RegionDefinition" unless definition.is_a?(RegionDefinition)
+
+      repository.add_region_definition definition
     end
 
     def any_holidays_during_work_week?(date, *options)

--- a/lib/holidays/parser.rb
+++ b/lib/holidays/parser.rb
@@ -8,7 +8,10 @@ module Holidays::Parser
     # Load a region definition file into a `RegionDefinition` instance.
     def parse_definition_file(file)
       definition_file = YAML.load_file(file)
-      Holidays::RegionDefinition.from_yaml(definition_file)
+      region_definition = Holidays::RegionDefinition.from_yaml(definition_file)
+      region_definition.metadata[:filename] = file
+
+      region_definition
     rescue ArgumentError => error
       raise ArgumentError.new("Failed to parse #{file}: #{error.message}")
     end

--- a/lib/holidays/repository.rb
+++ b/lib/holidays/repository.rb
@@ -1,95 +1,132 @@
+require 'holidays/parser'
 
-module Holidays
-  # This class holds all of the holiday definitions, custom methods, and region info that have been loaded
-  # into the "runtime" of the library. When holidays are being queried, the data will come from this
-  # class.
-  class Repository
-    attr_reader :regions
-    attr_reader :region_metadata
-    attr_accessor :custom_methods
-    
-    def initialize
-      @holidays_by_month = {}
-      @custom_methods = {}
-      @regions = []
-      @region_metadata = {}
-    end
+# This class holds all of the holiday definitions, custom methods, and region info that have been loaded
+# into the "runtime" of the library. When holidays are being queried, the data will come from this
+# class.
+class Holidays::Repository
+  attr_reader :search_prefix
+  attr_reader :regions
+  attr_reader :region_metadata
+  attr_accessor :custom_methods
+  
+  def initialize(search_prefix)
+    @search_prefix = search_prefix
+    @holidays_by_month = {}
+    @custom_methods = {}
+    @regions = []
+    @region_metadata = {}
+  end
 
-    def add_region_definition(definition)
-      return if @regions.include?(definition.region)
+  def add_region_definition(definition)
+    return if @regions.include?(definition.region)
+    add_or_replace_region_definition(definition)      
+  end
 
-      @regions << definition.region
-      @region_metadata[definition.region] = definition.metadata
+  def add_or_replace_region_definition(definition)
+    @regions << definition.region
+    @region_metadata[definition.region] = definition.metadata
 
-      definition.month_rules.each do |month, rules|
-        @holidays_by_month[month] = [] unless @holidays_by_month[month]
+    definition.month_rules.each do |month, rules|
+      @holidays_by_month[month] = [] unless @holidays_by_month[month]
 
-        rules.each do |rule|
-          exists = false
-          @holidays_by_month[month].each do |holiday|
-            if holiday == rule
-              holiday.add_region definition.region
-              exists = true
-            end
+      rules.each do |rule|
+        exists = false
+        @holidays_by_month[month].each do |holiday|
+          if holiday == rule
+            holiday.add_region definition.region
+            exists = true
           end
-
-          @holidays_by_month[month] << rule unless exists
-        end
-      end
-
-      @custom_methods.merge! definition.custom_methods
-    end
-
-    def delete_region!(region)
-      region = region.to_sym
-      return unless @regions.include?(region)
-
-      @regions.delete(region)
-      @region_metadata.delete(region)
-
-      @holidays_by_month.each do |month, holidays|
-        holidays_to_remove = []
-        holidays.each do |holiday|
-          holiday.regions.delete(region)
-          holidays_to_remove << holiday if holiday.regions.empty?
         end
 
-        @holidays_by_month[month] = holidays - holidays_to_remove
+        @holidays_by_month[month] << rule unless exists
       end
     end
 
-    def get_holidays_for_month(month)
-      @holidays_by_month[month]
-    end
+    @custom_methods.merge! definition.custom_methods
+  end
 
-    # Returns an array of regions. If `region` is a "concrete" region name (i.e., not a wildcard) and the region
-    # exists in the `regions` array, then `region` will be returned as a single-item array. If `region` is a 
-    # wildcard, then all matching regions will be returned in an array. If `region` is a concrete name or wildcard
-    # with no corresponding item in `regions`, then an empty array will be returned.
-    def lookup_region(region)
-      return [] if region.nil?
+  def delete_region!(region)
+    region = region.to_sym
+    return unless @regions.include?(region)
 
-      if region.to_s.ends_with?('_') && !only_exact
-        parent_region = region.to_s.split('_').first
-        return regions.select { |r| r.to_s.start_with?(parent_region) }
-      elsif regions.include?(region)
-        return [region]
-      else 
-        return []
+    @regions.delete(region)
+    @region_metadata.delete(region)
+
+    @holidays_by_month.each do |month, holidays|
+      holidays_to_remove = []
+      holidays.each do |holiday|
+        holiday.regions.delete(region)
+        holidays_to_remove << holiday if holiday.regions.empty?
       end
+
+      @holidays_by_month[month] = holidays - holidays_to_remove
+    end
+  end
+
+  def sync!
+    definitions = definition_files
+
+    stale_regions = regions.reject do |region|
+      region_filename = region_metadata[region][:filename]
+      definitions.include? region_filename
     end
 
-    # Return `true` if the input region has been loaded. If the input region is a wildcard (ends with '_'),
-    # then any child region will count.
-    def includes_region?(region)
-      if region.to_s.ends_with?('_') && !only_exact
-        parent_region = region.to_s.split('_').first
-        # The region is a wildcard, which means we should return true if any subregion is present
-        @regions.any? { |r| r.to_s.start_with?(parent_region) }
-      else
-        # This region is not a wildcard, so we just do an exact match
-        @regions.include?(region)
-      end
+    new_definitions = definitions.reject do |definition|
+      region_metadata.values.any? { |metadata] metadata[:filename] == definition }
     end
+
+    stale_regions.each { |r| delete_region!(r) }
+    new_definitions.each do |definition|
+      region_def = Parser.parse_definition_file(definition)
+      add_or_replace_definition(region_def)
+    end
+
+  end
+
+  def get_holidays_for_month(month)
+    @holidays_by_month[month]
+  end
+
+  # Returns an array of regions. If `region` is a "concrete" region name (i.e., not a wildcard) and the region
+  # exists in the `regions` array, then `region` will be returned as a single-item array. If `region` is a 
+  # wildcard, then all matching regions will be returned in an array. If `region` is a concrete name or wildcard
+  # with no corresponding item in `regions`, then an empty array will be returned.
+  def lookup_region(region)
+    return [] if region.nil?
+
+    if region.to_s.ends_with?('_')
+      parent_region = region.to_s.split('_').first
+      return regions.select { |r| r.to_s.start_with?(parent_region) }
+    elsif @regions.include?(region)
+      return [region]
+    else 
+      return []
+    end
+  end
+
+  # Return `true` if the input region has been loaded. If the input region is a wildcard (ends with '_'),
+  # then any child region will count.
+  def includes_region?(region)
+    if region.to_s.ends_with?('_')
+      parent_region = region.to_s.split('_').first
+      # The region is a wildcard, which means we should return true if any subregion is present
+      @regions.any? { |r| r.to_s.start_with?(parent_region) }
+    else
+      # This region is not a wildcard, so we just do an exact match
+      @regions.include?(region)
+    end
+  end
+
+  private
+
+  def definition_files
+    filenames = []
+    Dir.entries(search_prefix).map do |item|
+      next if item == '.' || item == '..' || File.directory?(item)
+
+      filenames << "#{search_prefix}/#{item}"
+    end
+
+    return filenames
   end
 end

--- a/lib/holidays/repository.rb
+++ b/lib/holidays/repository.rb
@@ -77,7 +77,7 @@ class Holidays::Repository
 
     stale_regions.each { |r| delete_region!(r) }
     new_definitions.each do |definition|
-      region_def = Parser.parse_definition_file(definition)
+      region_def = Holidays::Parser.parse_definition_file(definition)
       add_or_replace_definition(region_def)
     end
 

--- a/lib/holidays/repository.rb
+++ b/lib/holidays/repository.rb
@@ -19,11 +19,11 @@ class Holidays::Repository
 
   def add_region_definition(definition)
     return if @regions.include?(definition.region)
-    add_or_replace_region_definition(definition)      
+    add_or_replace_region_definition(definition, true)
   end
 
-  def add_or_replace_region_definition(definition)
-    @regions << definition.region
+  def add_or_replace_region_definition(definition, region_exists = false)
+    @regions << definition.region unless region_exists or @regions.include?(definition.region)
     @region_metadata[definition.region] = definition.metadata
 
     definition.month_rules.each do |month, rules|

--- a/lib/holidays/repository.rb
+++ b/lib/holidays/repository.rb
@@ -72,7 +72,7 @@ class Holidays::Repository
     end
 
     new_definitions = definitions.reject do |definition|
-      region_metadata.values.any? { |metadata] metadata[:filename] == definition }
+      region_metadata.values.any? { |metadata| metadata[:filename] == definition }
     end
 
     stale_regions.each { |r| delete_region!(r) }

--- a/lib/holidays/repository.rb
+++ b/lib/holidays/repository.rb
@@ -78,7 +78,7 @@ class Holidays::Repository
     stale_regions.each { |r| delete_region!(r) }
     new_definitions.each do |definition|
       region_def = Holidays::Parser.parse_definition_file(definition)
-      add_or_replace_definition(region_def)
+      add_or_replace_region_definition(region_def)
     end
 
   end


### PR DESCRIPTION
Changing `Holidays::Repository` so that it's aware of the holiday definition files. This allows it to synchronize the data with changes to the data on disk, which is important to synchronize data across separate processes.